### PR TITLE
Replaced Scala futures with RxScala observables

### DIFF
--- a/dcs-client/.gitignore
+++ b/dcs-client/.gitignore
@@ -1,0 +1,37 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+ # compiled output
+/dist
+/dist-server
+/tmp
+/out-tsc
+ # dependencies
+/node_modules
+ # IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+ # IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+ # misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+ # e2e
+/e2e/*.js
+/e2e/*.map
+ # System Files
+.DS_Store
+Thumbs.db

--- a/dcs-commons/src/main/scala/it/unibo/dcs/commons/RxHelper.scala
+++ b/dcs-commons/src/main/scala/it/unibo/dcs/commons/RxHelper.scala
@@ -4,7 +4,7 @@ import io.vertx.core.{Context => JContext, Vertx => JVertx}
 import io.vertx.rx.java.{RxHelper => JRxHelper}
 import io.vertx.scala.core.{Context, Vertx}
 import it.unibo.dcs.commons.RxHelper.Implicits._
-import rx.lang.scala.Scheduler
+import rx.lang.scala.{Observable, Scheduler}
 
 object RxHelper {
 
@@ -23,6 +23,8 @@ object RxHelper {
     implicit def contextToJContext(context: Context): JContext = context.asJava.asInstanceOf[JContext]
 
     implicit final class RxScheduler(val asJavaScheduler: rx.Scheduler) extends Scheduler
+
+    implicit final class RxObservable[T](val asJavaObservable: rx.Observable[T]) extends Observable[T]
 
   }
 

--- a/dcs-commons/src/main/scala/it/unibo/dcs/commons/VertxHelper.scala
+++ b/dcs-commons/src/main/scala/it/unibo/dcs/commons/VertxHelper.scala
@@ -1,8 +1,8 @@
 package it.unibo.dcs.commons
 
 import io.vertx.core.{AsyncResult, Handler}
+import it.unibo.dcs.commons.RxHelper.Implicits.RxObservable
 import it.unibo.dcs.commons.VertxHelper.Implicits._
-import RxHelper.Implicits.RxObservable
 import rx.lang.scala.Observable
 
 object VertxHelper {

--- a/dcs-commons/src/main/scala/it/unibo/dcs/commons/VertxHelper.scala
+++ b/dcs-commons/src/main/scala/it/unibo/dcs/commons/VertxHelper.scala
@@ -1,9 +1,8 @@
 package it.unibo.dcs.commons
 
 import io.vertx.core.{AsyncResult, Handler}
-import it.unibo.dcs.commons.RxHelper.Implicits._
 import it.unibo.dcs.commons.VertxHelper.Implicits._
-import rx.functions.Func1
+import RxHelper.Implicits.RxObservable
 import rx.lang.scala.Observable
 
 object VertxHelper {
@@ -11,14 +10,12 @@ object VertxHelper {
   def toObservable[T](action: (AsyncResult[T] => Unit) => Unit): Observable[T] = toObservable[T, T](identity)(action)
 
   def toObservable[J, S](converter: J => S)(action: (AsyncResult[J] => Unit) => Unit): Observable[S] = {
-    val observable = io.vertx.rx.java.RxHelper.observableFuture[J]()
-    action(observable.toHandler())
-    observable.map[S](converter)
+    val javaObservable = io.vertx.rx.java.RxHelper.observableFuture[J]()
+    action(javaObservable.toHandler())
+    RxObservable[J](javaObservable).map[S](converter)
   }
 
   object Implicits {
-
-    implicit def func1ToFunction[T, R](func: Func1[T, R]): Function[T, R] = func.call
 
     implicit def handlerToFunction[T](handler: Handler[T]): Function[T, Unit] = handler.handle
 

--- a/dcs-commons/src/main/scala/it/unibo/dcs/commons/VertxHelper.scala
+++ b/dcs-commons/src/main/scala/it/unibo/dcs/commons/VertxHelper.scala
@@ -3,6 +3,7 @@ package it.unibo.dcs.commons
 import io.vertx.core.{AsyncResult, Handler}
 import it.unibo.dcs.commons.RxHelper.Implicits._
 import it.unibo.dcs.commons.VertxHelper.Implicits._
+import rx.functions.Func1
 import rx.lang.scala.Observable
 
 object VertxHelper {
@@ -12,10 +13,12 @@ object VertxHelper {
   def toObservable[J, S](converter: J => S)(action: (AsyncResult[J] => Unit) => Unit): Observable[S] = {
     val observable = io.vertx.rx.java.RxHelper.observableFuture[J]()
     action(observable.toHandler())
-    observable.map[S](e => converter(e))
+    observable.map[S](converter)
   }
 
   object Implicits {
+
+    implicit def func1ToFunction[T, R](func: Func1[T, R]): Function[T, R] = func.call
 
     implicit def handlerToFunction[T](handler: Handler[T]): Function[T, Unit] = handler.handle
 

--- a/dcs-commons/src/main/scala/it/unibo/dcs/commons/VertxHelper.scala
+++ b/dcs-commons/src/main/scala/it/unibo/dcs/commons/VertxHelper.scala
@@ -1,19 +1,18 @@
 package it.unibo.dcs.commons
 
 import io.vertx.core.{AsyncResult, Handler}
-import io.vertx.lang.scala.HandlerOps.handlerForAsyncResultWithConversion
-import it.unibo.dcs.commons.VertxHelper.Implicits.handlerToFunction
-
-import scala.concurrent.Future
+import it.unibo.dcs.commons.RxHelper.Implicits._
+import it.unibo.dcs.commons.VertxHelper.Implicits._
+import rx.lang.scala.Observable
 
 object VertxHelper {
 
-  def toFuture[T](action: (AsyncResult[T] => Unit) => Unit): Future[T] = toFuture[T, T](identity)(action)
+  def toObservable[T](action: (AsyncResult[T] => Unit) => Unit): Observable[T] = toObservable[T, T](identity)(action)
 
-  def toFuture[J, S](converter: J => S)(action: (AsyncResult[J] => Unit) => Unit): Future[S] = {
-    val (handler, promise) = handlerForAsyncResultWithConversion[J, S](converter)
-    action(handler)
-    promise.future
+  def toObservable[J, S](converter: J => S)(action: (AsyncResult[J] => Unit) => Unit): Observable[S] = {
+    val observable = io.vertx.rx.java.RxHelper.observableFuture[J]()
+    action(observable.toHandler())
+    observable.map[S](e => converter(e))
   }
 
   object Implicits {

--- a/dcs-service-commons/src/main/scala/it/unibo/dcs/commons/service/AbstractApi.scala
+++ b/dcs-service-commons/src/main/scala/it/unibo/dcs/commons/service/AbstractApi.scala
@@ -3,10 +3,8 @@ package it.unibo.dcs.commons.service
 import io.vertx.scala.ext.web.client.{HttpResponse, WebClient}
 import rx.lang.scala.Observable
 
-import scala.concurrent.ExecutionContext
-
 abstract class AbstractApi(private[this] val discovery: HttpEndpointDiscovery,
-                           private[this] val serviceName: String)(implicit executor: ExecutionContext) {
+                           private[this] val serviceName: String) {
 
   private[this] var clientOption: Option[WebClient] = None
 

--- a/dcs-service-commons/src/main/scala/it/unibo/dcs/commons/service/HttpEndpointDiscovery.scala
+++ b/dcs-service-commons/src/main/scala/it/unibo/dcs/commons/service/HttpEndpointDiscovery.scala
@@ -1,13 +1,12 @@
 package it.unibo.dcs.commons.service
 
 import io.vertx.scala.ext.web.client.WebClient
-
-import scala.concurrent.{ExecutionContext, Future}
+import rx.lang.scala.Observable
 
 trait HttpEndpointDiscovery {
 
-  def getWebClient(name: String)(implicit executor: ExecutionContext): Future[WebClient]
+  def getWebClient(name: String): Observable[WebClient]
 
-  def getWebClientOrFail(name: String)(implicit executor: ExecutionContext): Future[WebClient]
+  def getWebClientOrFail(name: String): Observable[WebClient]
 
 }

--- a/dcs-service-commons/src/main/scala/it/unibo/dcs/commons/service/HttpEndpointDiscoveryImpl.scala
+++ b/dcs-service-commons/src/main/scala/it/unibo/dcs/commons/service/HttpEndpointDiscoveryImpl.scala
@@ -1,7 +1,7 @@
 package it.unibo.dcs.commons.service
 
+import io.vertx.core.Future
 import io.vertx.core.json.JsonObject
-import io.vertx.core.{Future => VFuture}
 import io.vertx.ext.web.client.{WebClient => JWebClient}
 import io.vertx.scala.core.eventbus.EventBus
 import io.vertx.scala.ext.web.client.WebClient
@@ -11,30 +11,30 @@ import it.unibo.dcs.commons.VertxHelper
 import it.unibo.dcs.commons.VertxHelper.Implicits._
 import it.unibo.dcs.commons.service.Constants.PUBLISH_CHANNEL
 import it.unibo.dcs.commons.service.HttpEndpointDiscoveryImpl.RECORD_TYPE
-
-import scala.concurrent.{ExecutionContext, Future}
+import rx.lang.scala.Observable
 
 final class HttpEndpointDiscoveryImpl(private[this] val discovery: ServiceDiscovery,
                                       private[this] val eventBus: EventBus) extends HttpEndpointDiscovery {
 
-  override def getWebClient(name: String)(implicit executor: ExecutionContext): Future[WebClient] =
+  override def getWebClient(name: String): Observable[WebClient] =
     getWebClientOrFail(name)
-      .recoverWith {
-        case _ => VertxHelper.toFuture[JWebClient, WebClient](WebClient(_)) { handler =>
+      .onErrorResumeNext[WebClient] {
+      _ =>
+        VertxHelper.toObservable[JWebClient, WebClient](WebClient(_)) { handler =>
           val consumer = eventBus.consumer[Record](PUBLISH_CHANNEL)
           consumer.handler { message =>
             val record = message.body
             if (record.getName == name && record.getType == RECORD_TYPE) {
               val webClient = discovery.getReference(record).getAs(classOf[JWebClient])
-              handler(VFuture.succeededFuture(webClient))
+              handler(Future.succeededFuture(webClient))
               consumer.unregister()
             }
           }
         }
-      }
+    }
 
-  override def getWebClientOrFail(name: String)(implicit executor: ExecutionContext): Future[WebClient] =
-    VertxHelper.toFuture[JWebClient, WebClient](WebClient(_)) { handler =>
+  override def getWebClientOrFail(name: String): Observable[WebClient] =
+    VertxHelper.toObservable[JWebClient, WebClient](WebClient(_)) { handler =>
       HttpEndpoint.getWebClient(
         discovery,
         new JsonObject()

--- a/dcs-service-commons/src/main/scala/it/unibo/dcs/commons/service/HttpEndpointPublisher.scala
+++ b/dcs-service-commons/src/main/scala/it/unibo/dcs/commons/service/HttpEndpointPublisher.scala
@@ -3,8 +3,7 @@ package it.unibo.dcs.commons.service
 import io.vertx.core.json.JsonObject
 import io.vertx.servicediscovery.Record
 import it.unibo.dcs.commons.service.HttpEndpointPublisher._
-
-import scala.concurrent.{ExecutionContext, Future}
+import rx.lang.scala.Observable
 
 trait HttpEndpointPublisher {
 
@@ -13,11 +12,11 @@ trait HttpEndpointPublisher {
               host: String = DEFAULT_HOST,
               port: Int = DEFAULT_PORT,
               root: String = DEFAULT_ROOT,
-              metadata: JsonObject = DEFAULT_METADATA): Future[Record]
+              metadata: JsonObject = DEFAULT_METADATA): Observable[Record]
 
-  def unpublish(record: Record): Future[Record]
+  def unpublish(record: Record): Observable[Record]
 
-  def clear()(implicit executor: ExecutionContext): Future[Unit]
+  def clear(): Observable[Unit]
 
 }
 

--- a/dcs-service-commons/src/main/scala/it/unibo/dcs/commons/service/ServiceVerticle.scala
+++ b/dcs-service-commons/src/main/scala/it/unibo/dcs/commons/service/ServiceVerticle.scala
@@ -26,7 +26,7 @@ abstract class ServiceVerticle extends ScalaVerticle {
   protected final def startHttpServer(host: String,
                                       port: Int,
                                       options: HttpServerOptions = DEFAULT_OPTIONS): Observable[HttpServer] =
-    VertxHelper.toObservable { handler =>
+    VertxHelper.toObservable[HttpServer] { handler =>
       vertx.createHttpServer(options)
         .requestHandler(_router accept _)
         .listen(port, host, handler)

--- a/dcs-service-commons/src/main/scala/it/unibo/dcs/commons/service/ServiceVerticle.scala
+++ b/dcs-service-commons/src/main/scala/it/unibo/dcs/commons/service/ServiceVerticle.scala
@@ -5,9 +5,10 @@ import io.vertx.lang.scala.ScalaVerticle
 import io.vertx.scala.core.eventbus.EventBus
 import io.vertx.scala.core.http.{HttpServer, HttpServerOptions}
 import io.vertx.scala.ext.web.Router
+import it.unibo.dcs.commons.VertxHelper
+import it.unibo.dcs.commons.VertxHelper.Implicits._
 import it.unibo.dcs.commons.service.ServiceVerticle._
-
-import scala.concurrent.Future
+import rx.lang.scala.Observable
 
 abstract class ServiceVerticle extends ScalaVerticle {
 
@@ -24,10 +25,13 @@ abstract class ServiceVerticle extends ScalaVerticle {
 
   protected final def startHttpServer(host: String,
                                       port: Int,
-                                      options: HttpServerOptions = DEFAULT_OPTIONS): Future[HttpServer] =
-    vertx.createHttpServer(options)
-      .requestHandler(_router accept _)
-      .listenFuture(port, host)
+                                      options: HttpServerOptions = DEFAULT_OPTIONS): Observable[HttpServer] =
+    VertxHelper.toObservable { handler =>
+      vertx.createHttpServer(options)
+        .requestHandler(_router accept _)
+        .listen(port, host, handler)
+    }
+
 
   protected def initializeRouter(router: Router): Unit
 


### PR DESCRIPTION
I have replaced all Scala futures with RxScala observables so that all asynchronous computations happen with RxScala observables instead of mixing Scala futures and RxScala observables